### PR TITLE
fix "null" in stripe donor names

### DIFF
--- a/src/components/ButtonStripe.tsx
+++ b/src/components/ButtonStripe.tsx
@@ -19,7 +19,7 @@ export default function ButtonStripe(props: {
         { price: props.price_id, quantity: 1 },
       ],
       mode: "subscription",
-      clientReferenceId: props.donorname + sep + props.forumname,
+      clientReferenceId: (props.donorname || "") + sep + (props.forumname || ""),
       successUrl: process.env.GATSBY_SITEURL + "/donate/success-stripe",
       cancelUrl: process.env.GATSBY_SITEURL + "/donate",
     });

--- a/src/pages/donate/by-stripe.tsx
+++ b/src/pages/donate/by-stripe.tsx
@@ -38,17 +38,11 @@ export default class PageStripe extends React.Component {
     const handleOneTimeClick = async event => {
       // When the customer clicks on the button, redirect them to Checkout.
       let sep = "\u2028";
-      let donorname = "";
       if (this.state.otPrice === "" || !/^\d+$/.test(this.state.otPrice)) {
         return;
       }
-      if (this.state.donor != "") {
-        donorname = this.state.donor;
-      }
-      let forumname = "";
-      if (this.state.forum != "") {
-        forumname = this.state.forum;
-      }
+      let donorname = this.state.donor || "";
+      let forumname = this.state.forum || "";
       let current_datetime = new Date();
       const stripe = await stripePromise;
       const { error } = await stripe.redirectToCheckout({


### PR DESCRIPTION
By default, state.donor and state.forum are `null`, but `null != ""`, so the `null` gets copied into the stripe request and converted to the string `null`. Work around this by defaulting to `""`.