### PR TITLE
Fix translations wiki link

### DIFF
--- a/src/components/SectionWidgets.tsx
+++ b/src/components/SectionWidgets.tsx
@@ -170,7 +170,7 @@ function ContributeGallery() {
       >
         Get involved with Kodi Foundation by making Kodi, add-ons and other projects
         available in your language. [Our translation system wiki page has more
-        detailed information](https://kodi.wiki/index.php?title=Translation_System).
+        detailed information](https://kodi.wiki/index.php?title=Translations).
       </FeaturedCard>
 
       <FeaturedCard


### PR DESCRIPTION
This will fix the wiki translations link to `https://kodi.wiki/index.php?title=Translations`