### PR TITLE
Use correct case for "GitHub" in recent blog and evergreen pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then open [http://localhost:8000](http://localhost:8000) in your browser to see 
 
 ## Issues
 
-If you are having issues with the site, please submit a Github issue.
+If you are having issues with the site, please submit a GitHub issue.
 
 ## Content
 

--- a/src/content/article/kodi-21-2-omega-release/index.md
+++ b/src/content/article/kodi-21-2-omega-release/index.md
@@ -14,7 +14,7 @@ featured_image:
 
 New Year, New Kodi? Not quite, but here we go with the next point release of the 21.x "Omega" series.
 
-The usual story: bugfixes, not features. The full changelog can be found on [Github](https://github.com/xbmc/xbmc/compare/21.1-Omega...21.2-Omega), as usual.
+The usual story: bugfixes, not features. The full changelog can be found on [GitHub](https://github.com/xbmc/xbmc/compare/21.1-Omega...21.2-Omega), as usual.
 
 ### Release Summary
 
@@ -88,7 +88,7 @@ Major user-facing changes include:
 * Fixed HDR feature did not work on Windows 11 24H2 under some circumstances ([PR](https://github.com/xbmc/xbmc/pull/26135)) 
 * Improved support for WCG displays on Windows 11 24H2 ([PR](https://github.com/xbmc/xbmc/pull/26135)) 
 
-We always want to thank everyone who has helped us track down and fix any issues. We endeavour to minimise the issues everyone experiences, but with such a large project, and the fact everyone contributing to Kodi is a volunteer, issues and bugs are a part of life. If you happen to experience any bugs/issues, don't hesitate to reach out on the forums, or raise an issue on Github.
+We always want to thank everyone who has helped us track down and fix any issues. We endeavour to minimise the issues everyone experiences, but with such a large project, and the fact everyone contributing to Kodi is a volunteer, issues and bugs are a part of life. If you happen to experience any bugs/issues, don't hesitate to reach out on the forums, or raise an issue on GitHub.
 
 As this is a point release, there are no major changes since the previous version, and you should be fine to install this straight over the top of any existing Kodi 21.x installation - indeed, this will happen automatically on many platforms. However, as for all software installations, back up your userdata beforehand if you've any doubts or have anything you can't afford to lose (and definitely do this if you're going for a major version upgrade).
 

--- a/src/content/pages/contribute/developers.md
+++ b/src/content/pages/contribute/developers.md
@@ -21,7 +21,7 @@ Any bug fixes can be sent to our main github code repository for review straight
 
 - [Wiki pages to get you started](https://kodi.wiki/view/Development)
 - [Developers Forum](https://forum.kodi.tv/forumdisplay.php?fid=32)
-- [Code on Github](https://github.com/xbmc/xbmc)
+- [Code on GitHub](https://github.com/xbmc/xbmc)
 
 So why do we need you? Well the fact is that over the years the core team of Kodi has remained about the same size while the number of users went from a couple thousand to many, many millions while expanding from an XBOX only application to running on Linux, Windows, iOS, OSX, Raspberry Pi, and Android. Now the time has come to start calling out for some help.
 

--- a/src/hooks/Stats.tsx
+++ b/src/hooks/Stats.tsx
@@ -17,7 +17,7 @@ export const Stats = () => {
   }[] = [];
   stats.push({
     key: "gitcommits",
-    title: "Github Commits",
+    title: "GitHub Commits",
     value: statsYaml.gitcommits,
   });
   stats.push({


### PR DESCRIPTION
I noticed "Github" in the most recent blog post, wanted to correct that, but found a few other instances worth changing so have included those here.

There are a few dozen more instances on old blog posts which I'm happy to search and replace too, if desired.

By the way, yeah, I always thought it was "Github" too but apparently it's "GitHub".