### PR TITLE
Keep side rails below header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -195,9 +195,12 @@ function Header(props: any) {
     mainclassname = "bg-kodibg";
     showtitle = false;
   }
+  const sideRailOverlapAttributes = showtitle
+    ? { "google-side-rail-overlap": "false" }
+    : {};
   return (
     <>
-      <div className={mainclassname}>
+      <div className={mainclassname} {...sideRailOverlapAttributes}>
         <nav className="glass-dark sticky top-0 z-50">
           <div className="max-w-7xl mx-auto px-2 lg:px-6">
             <div>


### PR DESCRIPTION
## Summary
- mark the shared dark header area as excluded from side rail overlap
- lets side rail ads start in the white content area on download and download receipt pages

## Verification
- corepack pnpm check:lint (0 errors, existing warnings)
- corepack pnpm build
- corepack pnpm test (64 tests passed)
- rg confirmed google-side-rail-overlap renders in dist/download/linux/index.html and dist/download/thanks/linux/index.html