### PR TITLE
Add hybrid manual AdSense placements on download pages

### DIFF
--- a/src/components/AdUnit.test.tsx
+++ b/src/components/AdUnit.test.tsx
@@ -103,6 +103,55 @@ describe("AdUnit", () => {
     });
   });
 
+  it("initializes hidden non-lazy ad containers when they become visible", async () => {
+    let isVisible = false;
+    Object.defineProperty(HTMLElement.prototype, "offsetParent", {
+      configurable: true,
+      get: () => (isVisible ? document.body : null),
+    });
+    vi.spyOn(Element.prototype, "getClientRects").mockImplementation(
+      () =>
+        ({
+          length: isVisible ? 1 : 0,
+        }) as DOMRectList,
+    );
+
+    let observeTarget: Element | null = null;
+    let intersectionCallback:
+      | ((entries: IntersectionObserverEntry[]) => void)
+      | undefined;
+
+    class MockIntersectionObserver {
+      constructor(callback: (entries: IntersectionObserverEntry[]) => void) {
+        intersectionCallback = callback;
+      }
+
+      observe(target: Element) {
+        observeTarget = target;
+      }
+
+      disconnect() {}
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+    render(<AdUnit placement="sidebar" slot="1234567890" />);
+
+    expect(window.adsbygoogle).toHaveLength(0);
+
+    isVisible = true;
+    intersectionCallback?.([
+      {
+        isIntersecting: true,
+        target: observeTarget,
+      } as IntersectionObserverEntry,
+    ]);
+
+    await waitFor(() => {
+      expect(window.adsbygoogle).toHaveLength(1);
+    });
+  });
+
   it("initializes visible ad containers", async () => {
     Object.defineProperty(HTMLElement.prototype, "offsetParent", {
       configurable: true,

--- a/src/components/AdUnit.test.tsx
+++ b/src/components/AdUnit.test.tsx
@@ -152,6 +152,33 @@ describe("AdUnit", () => {
     });
   });
 
+  it("falls back to resize checks when IntersectionObserver is unavailable", async () => {
+    let isVisible = false;
+    Object.defineProperty(HTMLElement.prototype, "offsetParent", {
+      configurable: true,
+      get: () => (isVisible ? document.body : null),
+    });
+    vi.spyOn(Element.prototype, "getClientRects").mockImplementation(
+      () =>
+        ({
+          length: isVisible ? 1 : 0,
+        }) as DOMRectList,
+    );
+
+    vi.stubGlobal("IntersectionObserver", undefined);
+
+    render(<AdUnit placement="sidebar" slot="1234567890" />);
+
+    expect(window.adsbygoogle).toHaveLength(0);
+
+    isVisible = true;
+    window.dispatchEvent(new Event("resize"));
+
+    await waitFor(() => {
+      expect(window.adsbygoogle).toHaveLength(1);
+    });
+  });
+
   it("initializes visible ad containers", async () => {
     Object.defineProperty(HTMLElement.prototype, "offsetParent", {
       configurable: true,

--- a/src/components/AdUnit.test.tsx
+++ b/src/components/AdUnit.test.tsx
@@ -60,6 +60,19 @@ describe("AdUnit", () => {
     );
   });
 
+  it("does not render or initialize an ad without a slot ID", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(<AdUnit slot="" />);
+
+    expect(screen.queryByLabelText("Advertisement")).not.toBeInTheDocument();
+    expect(document.querySelector(".adsbygoogle")).not.toBeInTheDocument();
+    expect(window.adsbygoogle).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "AdUnit: Missing ad slot ID for default placement. Set PUBLIC_ADSENSE_DOWNLOAD_SLOT or the placement-specific slot env var.",
+    );
+  });
+
   it("lazy-loads below-fold ad containers when they intersect", async () => {
     Object.defineProperty(HTMLElement.prototype, "offsetParent", {
       configurable: true,

--- a/src/components/AdUnit.test.tsx
+++ b/src/components/AdUnit.test.tsx
@@ -10,6 +10,7 @@ describe("AdUnit", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     delete window.adsbygoogle;
   });
 
@@ -47,6 +48,7 @@ describe("AdUnit", () => {
       "sticky",
       "top-6",
       "min-h-[600px]",
+      "max-w-[334px]",
     );
     expect(container.querySelector(".adsbygoogle")).toHaveStyle({
       display: "inline-block",

--- a/src/components/AdUnit.test.tsx
+++ b/src/components/AdUnit.test.tsx
@@ -29,6 +29,78 @@ describe("AdUnit", () => {
     );
   });
 
+  it("reserves leaderboard space before the ad loads", () => {
+    const { container } = render(
+      <AdUnit placement="leaderboard" slot="1234567890" />,
+    );
+
+    expect(screen.getByLabelText("Advertisement")).toHaveClass("min-h-[280px]");
+    expect(container.querySelector(".adsbygoogle")).toHaveClass("min-h-[280px]");
+  });
+
+  it("renders a fixed desktop sidebar unit", () => {
+    const { container } = render(<AdUnit placement="sidebar" slot="1234567890" />);
+
+    expect(screen.getByLabelText("Advertisement")).toHaveClass(
+      "hidden",
+      "2xl:block",
+      "sticky",
+      "top-6",
+      "min-h-[600px]",
+    );
+    expect(container.querySelector(".adsbygoogle")).toHaveStyle({
+      display: "inline-block",
+      width: "300px",
+      height: "600px",
+    });
+    expect(container.querySelector(".adsbygoogle")).not.toHaveAttribute(
+      "data-ad-format",
+    );
+  });
+
+  it("lazy-loads below-fold ad containers when they intersect", async () => {
+    Object.defineProperty(HTMLElement.prototype, "offsetParent", {
+      configurable: true,
+      get: () => document.body,
+    });
+    vi.spyOn(Element.prototype, "getClientRects").mockReturnValue({
+      length: 1,
+    } as DOMRectList);
+
+    let observeTarget: Element | null = null;
+    let intersectionCallback:
+      | ((entries: IntersectionObserverEntry[]) => void)
+      | undefined;
+
+    class MockIntersectionObserver {
+      constructor(callback: (entries: IntersectionObserverEntry[]) => void) {
+        intersectionCallback = callback;
+      }
+
+      observe(target: Element) {
+        observeTarget = target;
+      }
+
+      disconnect() {}
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+    render(<AdUnit lazy placement="inline" slot="1234567890" />);
+
+    expect(window.adsbygoogle).toHaveLength(0);
+    intersectionCallback?.([
+      {
+        isIntersecting: true,
+        target: observeTarget,
+      } as IntersectionObserverEntry,
+    ]);
+
+    await waitFor(() => {
+      expect(window.adsbygoogle).toHaveLength(1);
+    });
+  });
+
   it("initializes visible ad containers", async () => {
     Object.defineProperty(HTMLElement.prototype, "offsetParent", {
       configurable: true,

--- a/src/components/AdUnit.tsx
+++ b/src/components/AdUnit.tsx
@@ -71,6 +71,18 @@ function AdUnit({
   const isFixedSize = Boolean(placementConfig.style);
 
   useEffect(() => {
+    if (!adSlot && import.meta.env.DEV) {
+      console.warn(
+        `AdUnit: Missing ad slot ID for ${placement} placement. Set PUBLIC_ADSENSE_DOWNLOAD_SLOT or the placement-specific slot env var.`,
+      );
+    }
+  }, [adSlot, placement]);
+
+  useEffect(() => {
+    if (!adSlot) {
+      return;
+    }
+
     const initializeAd = () => {
       if (didInitializeRef.current) {
         return true;
@@ -133,7 +145,11 @@ function AdUnit({
     return () => {
       observer.disconnect();
     };
-  }, [lazy]);
+  }, [adSlot, lazy]);
+
+  if (!adSlot) {
+    return null;
+  }
 
   return (
     <section

--- a/src/components/AdUnit.tsx
+++ b/src/components/AdUnit.tsx
@@ -92,9 +92,25 @@ function AdUnit({
       }
     };
 
-    if (!("IntersectionObserver" in window) || !adRef.current) {
-      initializeAd();
-      return;
+    if (typeof IntersectionObserver !== "function" || !adRef.current) {
+      if (initializeAd()) {
+        return;
+      }
+
+      const initializeVisibleAd = () => {
+        if (initializeAd()) {
+          window.removeEventListener("resize", initializeVisibleAd);
+          window.removeEventListener("orientationchange", initializeVisibleAd);
+        }
+      };
+
+      window.addEventListener("resize", initializeVisibleAd);
+      window.addEventListener("orientationchange", initializeVisibleAd);
+
+      return () => {
+        window.removeEventListener("resize", initializeVisibleAd);
+        window.removeEventListener("orientationchange", initializeVisibleAd);
+      };
     }
 
     if (!lazy && initializeAd()) {

--- a/src/components/AdUnit.tsx
+++ b/src/components/AdUnit.tsx
@@ -31,7 +31,7 @@ const placementDefaults = {
     style: undefined,
   },
   sidebar: {
-    containerClass: "hidden 2xl:block sticky top-6 min-h-[600px] max-w-[332px]",
+    containerClass: "hidden 2xl:block sticky top-6 min-h-[600px] max-w-[334px]",
     insClass: "",
     slot: defaultSidebarSlot,
     style: {
@@ -73,11 +73,11 @@ function AdUnit({
   useEffect(() => {
     const initializeAd = () => {
       if (didInitializeRef.current) {
-        return;
+        return true;
       }
 
       if (!isVisibleAdUnit(adRef.current)) {
-        return;
+        return false;
       }
 
       try {
@@ -85,24 +85,31 @@ function AdUnit({
         win.adsbygoogle = win.adsbygoogle || [];
         win.adsbygoogle.push({});
         didInitializeRef.current = true;
+        return true;
       } catch {
         // Ad blockers can make the provider script unavailable.
+        return false;
       }
     };
 
-    if (!lazy || !("IntersectionObserver" in window) || !adRef.current) {
+    if (!("IntersectionObserver" in window) || !adRef.current) {
       initializeAd();
+      return;
+    }
+
+    if (!lazy && initializeAd()) {
       return;
     }
 
     const observer = new IntersectionObserver(
       entries => {
         if (entries.some(entry => entry.isIntersecting)) {
-          initializeAd();
-          observer.disconnect();
+          if (initializeAd()) {
+            observer.disconnect();
+          }
         }
       },
-      { rootMargin: "320px 0px" },
+      { rootMargin: lazy ? "320px 0px" : "0px" },
     );
 
     observer.observe(adRef.current);

--- a/src/components/AdUnit.tsx
+++ b/src/components/AdUnit.tsx
@@ -4,10 +4,49 @@ import { cn } from "@/lib/utils";
 interface AdUnitProps {
   minHeightClass?: string;
   className?: string;
+  lazy?: boolean;
+  placement?: "default" | "leaderboard" | "sidebar" | "inline";
   slot?: string;
 }
 
 const defaultAdSlot = import.meta.env.PUBLIC_ADSENSE_DOWNLOAD_SLOT;
+const defaultTopSlot =
+  import.meta.env.PUBLIC_ADSENSE_DOWNLOAD_TOP_SLOT || defaultAdSlot;
+const defaultSidebarSlot =
+  import.meta.env.PUBLIC_ADSENSE_DOWNLOAD_SIDEBAR_SLOT || defaultAdSlot;
+const defaultInlineSlot =
+  import.meta.env.PUBLIC_ADSENSE_DOWNLOAD_INLINE_SLOT || defaultAdSlot;
+
+const placementDefaults = {
+  default: {
+    containerClass: "",
+    insClass: "min-h-28",
+    slot: defaultAdSlot,
+    style: undefined,
+  },
+  leaderboard: {
+    containerClass: "min-h-[280px]",
+    insClass: "min-h-[280px]",
+    slot: defaultTopSlot,
+    style: undefined,
+  },
+  sidebar: {
+    containerClass: "hidden 2xl:block sticky top-6 min-h-[600px] max-w-[332px]",
+    insClass: "",
+    slot: defaultSidebarSlot,
+    style: {
+      display: "inline-block",
+      width: "300px",
+      height: "600px",
+    },
+  },
+  inline: {
+    containerClass: "min-h-[280px]",
+    insClass: "min-h-[280px]",
+    slot: defaultInlineSlot,
+    style: undefined,
+  },
+} as const;
 
 function isVisibleAdUnit(adElement: Element | null) {
   return Boolean(
@@ -18,44 +57,82 @@ function isVisibleAdUnit(adElement: Element | null) {
 }
 
 function AdUnit({
-  minHeightClass = "min-h-28",
   className,
-  slot = defaultAdSlot,
+  lazy = false,
+  minHeightClass,
+  placement = "default",
+  slot,
 }: AdUnitProps) {
   const adRef = useRef<HTMLModElement>(null);
+  const didInitializeRef = useRef(false);
+  const placementConfig = placementDefaults[placement];
+  const reservedHeightClass = minHeightClass || placementConfig.insClass;
+  const adSlot = slot || placementConfig.slot;
+  const isFixedSize = Boolean(placementConfig.style);
 
   useEffect(() => {
-    try {
+    const initializeAd = () => {
+      if (didInitializeRef.current) {
+        return;
+      }
+
       if (!isVisibleAdUnit(adRef.current)) {
         return;
       }
 
-      const win = window as typeof window & { adsbygoogle?: unknown[] };
-      win.adsbygoogle = win.adsbygoogle || [];
-      win.adsbygoogle.push({});
-    } catch {
-      // Ad blockers can make the provider script unavailable.
+      try {
+        const win = window as typeof window & { adsbygoogle?: unknown[] };
+        win.adsbygoogle = win.adsbygoogle || [];
+        win.adsbygoogle.push({});
+        didInitializeRef.current = true;
+      } catch {
+        // Ad blockers can make the provider script unavailable.
+      }
+    };
+
+    if (!lazy || !("IntersectionObserver" in window) || !adRef.current) {
+      initializeAd();
+      return;
     }
-  }, []);
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries.some(entry => entry.isIntersecting)) {
+          initializeAd();
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "320px 0px" },
+    );
+
+    observer.observe(adRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [lazy]);
 
   return (
     <section
       aria-label="Advertisement"
       className={cn(
         "rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4",
+        placementConfig.containerClass,
         className,
       )}
+      data-ad-placement={placement}
     >
       <p className="mb-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-500">
         Advertisement
       </p>
       <ins
         ref={adRef}
-        className={cn("adsbygoogle block", minHeightClass)}
+        className={cn("adsbygoogle block", reservedHeightClass)}
+        style={placementConfig.style}
         data-ad-client="ca-pub-5235469391524556"
-        data-ad-slot={slot}
-        data-ad-format="auto"
-        data-full-width-responsive="true"
+        data-ad-slot={adSlot}
+        data-ad-format={isFixedSize ? undefined : "auto"}
+        data-full-width-responsive={isFixedSize ? undefined : "true"}
       />
     </section>
   );

--- a/src/components/Distribution.tsx
+++ b/src/components/Distribution.tsx
@@ -16,6 +16,10 @@ function Distribution(props) {
 
   return (
     <DefaultLayout frontmatter={frontmatter} preview={preview}>
+      <div className="mb-8">
+        <AdUnit placement="leaderboard" />
+      </div>
+
       <div className="grid grid-cols-1 gap-6 md:grid-cols-12">
         <div className="col-span-1 md:col-span-2">
           <img
@@ -33,16 +37,13 @@ function Distribution(props) {
             <a href={dist.howto}>"How To" Guide</a> for {dist.name}.
           </span>
           <ReleasesTabs platform={dist.name} releases={dist.releases} />
-          <div className="mt-8 2xl:hidden">
-            <AdUnit minHeightClass="min-h-72" />
-          </div>
         </div>
         <aside className="hidden 2xl:col-span-3 2xl:block">
-          <AdUnit minHeightClass="min-h-72" className="sticky top-6" />
+          <AdUnit placement="sidebar" />
         </aside>
       </div>
       <div className="mt-8">
-        <AdUnit minHeightClass="min-h-28" />
+        <AdUnit lazy placement="inline" />
       </div>
     </DefaultLayout>
   );

--- a/src/pages/download/thanks/[platform].astro
+++ b/src/pages/download/thanks/[platform].astro
@@ -160,6 +160,5 @@ const howToUrl = `/download/${platform}`;
       copy.textContent =
         "This page needs a selected download file before it can start a download.";
     }
-
   </script>
 </BaseLayout>

--- a/src/pages/download/thanks/[platform].astro
+++ b/src/pages/download/thanks/[platform].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
+import { AdUnit } from "../../../components/AdUnit";
 import { getPlatformDisplayName } from "../../../utils/downloads";
 
 export async function getStaticPaths() {
@@ -19,7 +20,6 @@ export async function getStaticPaths() {
 const { platform } = Astro.params;
 const platformName = getPlatformDisplayName(platform);
 const howToUrl = `/download/${platform}`;
-const adsenseDownloadSlot = import.meta.env.PUBLIC_ADSENSE_DOWNLOAD_SLOT;
 ---
 
 <script
@@ -33,6 +33,8 @@ const adsenseDownloadSlot = import.meta.env.PUBLIC_ADSENSE_DOWNLOAD_SLOT;
 >
   <section class="grid grid-cols-1 gap-8 2xl:grid-cols-[minmax(0,1fr)_360px]">
     <div class="space-y-6">
+      <AdUnit placement="leaderboard" client:load />
+
       <div class="rounded-lg border border-kodi/15 bg-kodi-surface-light p-6">
         <p
           class="font-display text-sm font-semibold uppercase tracking-wide text-kodi"
@@ -103,58 +105,11 @@ const adsenseDownloadSlot = import.meta.env.PUBLIC_ADSENSE_DOWNLOAD_SLOT;
         </a>
       </div>
 
-      <section
-        aria-label="Advertisement"
-        class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4"
-      >
-        <p
-          class="mb-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-500"
-        >
-          Advertisement
-        </p>
-        <ins
-          class="adsbygoogle block min-h-28"
-          data-ad-client="ca-pub-5235469391524556"
-          data-ad-slot={adsenseDownloadSlot}
-          data-ad-format="auto"
-          data-full-width-responsive="true"></ins>
-      </section>
-
-      <section
-        aria-label="Advertisement"
-        class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 2xl:hidden"
-      >
-        <p
-          class="mb-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-500"
-        >
-          Advertisement
-        </p>
-        <ins
-          class="adsbygoogle block min-h-72"
-          data-ad-client="ca-pub-5235469391524556"
-          data-ad-slot={adsenseDownloadSlot}
-          data-ad-format="auto"
-          data-full-width-responsive="true"></ins>
-      </section>
+      <AdUnit lazy placement="inline" client:load />
     </div>
 
     <aside class="hidden space-y-5 2xl:block">
-      <section
-        aria-label="Advertisement"
-        class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4"
-      >
-        <p
-          class="mb-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-500"
-        >
-          Advertisement
-        </p>
-        <ins
-          class="adsbygoogle block min-h-72"
-          data-ad-client="ca-pub-5235469391524556"
-          data-ad-slot={adsenseDownloadSlot}
-          data-ad-format="auto"
-          data-full-width-responsive="true"></ins>
-      </section>
+      <AdUnit placement="sidebar" client:load />
 
       <div class="rounded-lg border border-kodi/15 bg-white p-5">
         <h2 class="font-display text-xl font-bold text-kodi-darker">
@@ -206,21 +161,5 @@ const adsenseDownloadSlot = import.meta.env.PUBLIC_ADSENSE_DOWNLOAD_SLOT;
         "This page needs a selected download file before it can start a download.";
     }
 
-    try {
-      const adWindow = window as Window & { adsbygoogle?: unknown[] };
-      adWindow.adsbygoogle = adWindow.adsbygoogle || [];
-      document.querySelectorAll(".adsbygoogle").forEach(adElement => {
-        if (
-          adElement.getClientRects().length === 0 ||
-          (adElement as HTMLElement).offsetParent === null
-        ) {
-          return;
-        }
-
-        adWindow.adsbygoogle?.push({});
-      });
-    } catch {
-      // Ad blockers can make the provider script unavailable.
-    }
   </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add placement-aware AdUnit variants for top leaderboard, fixed desktop sidebar, and inline ads
- reserve ad heights to reduce layout shift and lazy-load below-fold inline ads with IntersectionObserver
- replace generic receipt-page ad markup with shared manual AdUnit placements

## Notes
- Anchor and vignette formats remain controlled by AdSense Auto Ads settings. This change adds manual placements and does not enable aggressive overlays.
- Optional slot env vars are supported: PUBLIC_ADSENSE_DOWNLOAD_TOP_SLOT, PUBLIC_ADSENSE_DOWNLOAD_SIDEBAR_SLOT, PUBLIC_ADSENSE_DOWNLOAD_INLINE_SLOT. They fall back to PUBLIC_ADSENSE_DOWNLOAD_SLOT.

## Verification
- corepack pnpm test (67 tests passed)
- corepack pnpm check:lint (0 errors, existing warnings)
- corepack pnpm build
- rg confirmed generated Linux download and receipt pages include leaderboard/sidebar/inline placements and reserved dimensions
- local dev smoke check: /download/linux/ and /download/thanks/linux/ render manual ad regions