### PR TITLE
Fix Decap CMS config loading

### DIFF
--- a/src/cms/decap.tsx
+++ b/src/cms/decap.tsx
@@ -6,7 +6,6 @@ import { SponsorTypeList } from "../components/SponsorList";
 import { IconList } from "../components/IconList";
 import { Distribution } from "../components/Distribution";
 import type { Sponsor } from "../hooks/Sponsors";
-import siteConfig from "../config/site";
 
 const ArticlePreview = ({ entry, widgetsFor, getAsset }) => {
   let post = {};
@@ -148,7 +147,7 @@ CMS.registerPreviewTemplate("store", StoreItemPreview);
 
 export default function DecapCmsAdmin() {
   useEffect(() => {
-    CMS.init(siteConfig.cms);
+    CMS.init();
   }, []);
   return <div />;
 }

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -10,8 +10,11 @@ export const prerender = true;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Content Manager</title>
     <link rel="stylesheet" href="/admin/global.css" />
+    <link rel="cms-config-url" type="text/yaml" href="/admin/config.yml" />
   </head>
   <body>
-    <DecapCmsAdmin client:only="react" />
+    <div id="cms-root">
+      <DecapCmsAdmin client:only="react" />
+    </div>
   </body>
 </html>


### PR DESCRIPTION
CMS.init() was called with an incomplete config object from siteConfig.cms that only contained backend and site_url, causing the schema validation to fail with missing media_folder, collections, etc.

- Remove the incomplete config argument from CMS.init() so it falls back to auto-loading /admin/config.yml
- Add <link rel="cms-config-url"> in the admin page so Decap fetches the config from /admin/config.yml instead of the root /config.yml
- Wrap DecapCmsAdmin in a #cms-root div to prevent a React DOM conflict where both React and Decap CMS were trying to manage <body>